### PR TITLE
Remove msrestazure

### DIFF
--- a/src/saltext/azurerm/modules/azurerm_dns.py
+++ b/src/saltext/azurerm/modules/azurerm_dns.py
@@ -47,9 +47,7 @@ HAS_LIBS = False
 try:
     import azure.mgmt.dns.models  # pylint: disable=unused-import
     import azure.mgmt.privatedns.models  # pylint: disable=unused-import
-    from msrest.exceptions import SerializationError
-    from msrestazure.azure_exceptions import CloudError
-    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.exceptions import ResourceNotFoundError, HttpResponseError, SerializationError
 
     HAS_LIBS = True
 except ImportError:
@@ -138,7 +136,7 @@ def record_set_create_or_update(
                 if_none_match=kwargs.get("if_none_match"),
             )
         result = record_set.as_dict()
-    except ResourceNotFoundError as exc:
+    except (HttpResponseError, ResourceNotFoundError) as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
     except SerializationError as exc:
@@ -198,7 +196,7 @@ def record_set_delete(name, zone_name, resource_group, record_type, zone_type="P
                 if_match=kwargs.get("if_match"),
             )
         result = True
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
 
     return result
@@ -251,7 +249,7 @@ def record_set_get(name, zone_name, resource_group, record_type, zone_type="Publ
                 record_type=record_type,
             )
         result = record_set.as_dict()
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error(client, str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -327,7 +325,7 @@ def record_sets_list_by_type(
             )
         for record_set in record_sets:
             result[record_set["name"]] = record_set
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -392,7 +390,7 @@ def record_sets_list_by_dns_zone(
 
         for record_set in record_sets:
             result[record_set["name"]] = record_set
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -468,7 +466,7 @@ def zone_create_or_update(name, resource_group, zone_type="Public", **kwargs):
                 if_none_match=kwargs.get("if_none_match"),
             )
             result = zone.as_dict()
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
     except SerializationError as exc:
@@ -519,7 +517,7 @@ def zone_delete(name, resource_group, zone_type="Public", **kwargs):
             )
         zone.wait()
         result = True
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
 
     return result
@@ -560,7 +558,7 @@ def zone_get(name, resource_group, zone_type="Public", **kwargs):
             zone = dnsconn.zones.get(zone_name=name, resource_group_name=resource_group)
             result = zone.as_dict()
 
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -609,7 +607,7 @@ def zones_list_by_resource_group(resource_group, zone_type="Public", top=None, *
 
         for zone in zones:
             result[zone["name"]] = zone
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -652,7 +650,7 @@ def zones_list(top=None, zone_type="Public", **kwargs):
 
         for zone in zones:
             result[zone["name"]] = zone
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 

--- a/src/saltext/azurerm/modules/azurerm_keyvault_key.py
+++ b/src/saltext/azurerm/modules/azurerm_keyvault_key.py
@@ -48,8 +48,8 @@ try:
         ResourceNotFoundError,
         HttpResponseError,
         ResourceExistsError,
+        SerializationError,
     )
-    from msrest.exceptions import ValidationError, SerializationError
 
     HAS_LIBS = True
 except ImportError:
@@ -143,7 +143,7 @@ def backup_key(name, vault_url, **kwargs):
         backup = kconn.backup_key(name=name)
 
         result = backup
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -175,7 +175,7 @@ def begin_delete_key(name, vault_url, **kwargs):
 
         key.wait()
         result = _key_as_dict(key.result())
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -278,7 +278,7 @@ def create_ec_key(
         )
 
         result = _key_as_dict(key)
-    except (ValidationError, HttpResponseError) as exc:
+    except HttpResponseError as exc:
         result = {"error": str(exc)}
 
     return result
@@ -354,7 +354,7 @@ def create_key(
         )
 
         result = _key_as_dict(key)
-    except (ValidationError, HttpResponseError) as exc:
+    except HttpResponseError as exc:
         result = {"error": str(exc)}
 
     return result
@@ -423,7 +423,7 @@ def create_rsa_key(
         )
 
         result = _key_as_dict(key)
-    except (ValidationError, HttpResponseError) as exc:
+    except HttpResponseError as exc:
         result = {"error": str(exc)}
 
     return result
@@ -453,7 +453,7 @@ def get_deleted_key(name, vault_url, **kwargs):
         key = kconn.get_deleted_key(name=name)
 
         result = _key_as_dict(key)
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -485,7 +485,7 @@ def get_key(name, vault_url, version=None, **kwargs):
         key = kconn.get_key(name=name, version=version)
 
         result = _key_as_dict(key)
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -596,7 +596,7 @@ def import_key(
         )
 
         result = _key_as_dict(key)
-    except (HttpResponseError, ResourceNotFoundError) as exc:
+    except HttpResponseError as exc:
         result = {"error": str(exc)}
 
     return result
@@ -753,7 +753,7 @@ def restore_key_backup(backup, vault_url, **kwargs):
         )
 
         result = _key_as_dict(key)
-    except (ResourceExistsError, SerializationError) as exc:
+    except (ResourceExistsError, HttpResponseError, SerializationError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -818,7 +818,7 @@ def update_key_properties(
         )
 
         result = _key_as_dict(key)
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result

--- a/src/saltext/azurerm/modules/azurerm_keyvault_secret.py
+++ b/src/saltext/azurerm/modules/azurerm_keyvault_secret.py
@@ -48,8 +48,8 @@ try:
         ResourceNotFoundError,
         HttpResponseError,
         ResourceExistsError,
+        SerializationError,
     )
-    from msrest.exceptions import SerializationError
 
     HAS_LIBS = True
 except ImportError:
@@ -196,7 +196,7 @@ def delete_secret(name, vault_url, wait=False, **kwargs):
             secret.wait()
 
         result = True
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -270,7 +270,7 @@ def get_deleted_secret(name, vault_url, **kwargs):
         )
 
         result = _secret_as_dict(secret)
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -335,7 +335,7 @@ def list_deleted_secrets(vault_url, **kwargs):
 
         for secret in secrets:
             result[secret.name] = _secret_as_dict(secret)
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -370,7 +370,7 @@ def list_properties_of_secret_versions(name, vault_url, **kwargs):
 
         for secret in secrets:
             result[secret.name] = _secret_properties_as_dict(secret)
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -401,7 +401,7 @@ def list_properties_of_secrets(vault_url, **kwargs):
 
         for secret in secrets:
             result[secret.name] = _secret_properties_as_dict(secret)
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -471,7 +471,7 @@ def restore_secret_backup(backup, vault_url, **kwargs):
         )
 
         result = _secret_as_dict(secret)
-    except (ResourceExistsError, SerializationError) as exc:
+    except (ResourceExistsError, SerializationError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result
@@ -604,7 +604,7 @@ def update_secret_properties(
         )
 
         result = _secret_as_dict(secret)
-    except ResourceNotFoundError as exc:
+    except (ResourceNotFoundError, HttpResponseError) as exc:
         result = {"error": str(exc)}
 
     return result

--- a/src/saltext/azurerm/modules/azurerm_keyvault_vault.py
+++ b/src/saltext/azurerm/modules/azurerm_keyvault_vault.py
@@ -43,8 +43,7 @@ import saltext.azurerm.utils.azurerm
 HAS_LIBS = False
 try:
     import azure.mgmt.keyvault.models  # pylint: disable=unused-import
-    from msrestazure.azure_exceptions import CloudError
-    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 
     HAS_LIBS = True
 except ImportError:
@@ -79,7 +78,7 @@ def check_name_availability(name, **kwargs):
         )
 
         result = avail.as_dict()
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -248,7 +247,7 @@ def create_or_update(
 
         vault.wait()
         result = vault.result().as_dict()
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -279,7 +278,7 @@ def delete(name, resource_group, **kwargs):
         vconn.vaults.delete(vault_name=name, resource_group_name=resource_group)
 
         result = True
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
 
     return result
@@ -309,7 +308,7 @@ def get(name, resource_group, **kwargs):
         vault = vconn.vaults.get(vault_name=name, resource_group_name=resource_group)
 
         result = vault.as_dict()
-    except (ResourceNotFoundError, CloudError) as exc:
+    except (HttpResponseError, ResourceNotFoundError) as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -340,7 +339,7 @@ def get_deleted(name, location, **kwargs):
         vault = vconn.vaults.get_deleted(vault_name=name, location=location)
 
         result = vault.as_dict()
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -377,7 +376,7 @@ def list_(resource_group=None, top=None, **kwargs):
 
         for vault in vaults:
             result[vault["name"]] = vault
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -409,7 +408,7 @@ def list_by_subscription(top=None, **kwargs):
 
         for vault in vaults:
             result[vault["name"]] = vault
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -437,7 +436,7 @@ def list_deleted(**kwargs):
 
         for vault in vaults:
             result[vault["name"]] = vault
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
         result = {"error": str(exc)}
 
@@ -469,7 +468,7 @@ def purge_deleted(name, location, **kwargs):
 
         vault.wait()
         result = True
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
 
     return result
@@ -542,7 +541,7 @@ def update_access_policy(name, resource_group, operation_kind, access_policies, 
         )
 
         result = vault.as_dict()
-    except CloudError as exc:
+    except HttpResponseError as exc:
         saltext.azurerm.utils.azurerm.log_cloud_error("keyvault", str(exc), **kwargs)
         result = {"error": str(exc)}
 

--- a/src/saltext/azurerm/utils/azurerm.py
+++ b/src/saltext/azurerm/utils/azurerm.py
@@ -66,6 +66,11 @@ def _determine_auth(**kwargs):
     """
     Acquire Azure Resource Manager Credentials
     """
+    mrest_cloud_name = {
+        "AZURE_CHINA": "AZURE_CHINA_CLOUD",
+        "AZURE_GOVERNMENT": "AZURE_US_GOV_CLOUD",
+        "AZURE_GERMANY": "AZURE_GERMAN_CLOUD",
+    }
     if "profile" in kwargs:
         azure_credentials = __salt__["config.option"](kwargs["profile"])
         kwargs.update(azure_credentials)
@@ -76,9 +81,15 @@ def _determine_auth(**kwargs):
             authority = kwargs["cloud_environment"]
         else:
             cloud_env_module = importlib.import_module("msrestazure.azure_cloud")
-            cloud_env = getattr(
-                cloud_env_module, kwargs.get("cloud_environment", "AZURE_PUBLIC_CLOUD")
+
+            # Map the new cloud_environment name to the corresponding old msrest name
+            old_cloud_env_name = mrest_cloud_name.get(
+                kwargs.get("cloud_environment", "AZURE_PUBLIC_CLOUD"), "AZURE_PUBLIC_CLOUD"
             )
+
+            # Retrieve the cloud environment based on the old msrest name
+            cloud_env = getattr(cloud_env_module, old_cloud_env_name)
+
             authority = getattr(
                 AzureAuthorityHosts, kwargs.get("cloud_environment", "AZURE_PUBLIC_CLOUD")
             )


### PR DESCRIPTION
### What does this PR do?
This PR aims to remove the dependency on msrestazure. The bulk of the changes involves replacing the usage of msrestazure.azure_exceptions.CloudError with azure.core.exceptions import HttpResponseError.

### Note: 
There are still two instances where msrest functionality is required for retrieving cloud metadata. The specific locations where msrest is still used are:
- src/saltext/azurerm/clouds/azurerm.py
- src/saltext/azurerm/utils/azurerm.py