### PR TITLE
Add pytest-ordering, Add test_absent func for second ip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ lint = [
 ]
 tests = [
     "pytest>=6.1.0",
+    "pytest-ordering>=0.6",
     "pytest-salt-factories>=1.0.0rc19",
 ]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,9 +49,11 @@ def tags():
 
 @pytest.fixture(scope="session")
 def resource_group():
-    yield "rg-salt-inttest-" + "".join(
-        random.choice(string.ascii_lowercase + string.digits) for _ in range(20)
-    )
+    # yield "rg-salt-inttest-" + "".join(
+    # random.choice(string.ascii_lowercase + string.digits) for _ in range(20)
+    # )
+    #
+    yield "github"
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,10 +49,6 @@ def tags():
 
 @pytest.fixture(scope="session")
 def resource_group():
-    # yield "rg-salt-inttest-" + "".join(
-    # random.choice(string.ascii_lowercase + string.digits) for _ in range(20)
-    # )
-    #
     yield "github"
 
 

--- a/tests/integration/states/test_public_ip_address.py
+++ b/tests/integration/states/test_public_ip_address.py
@@ -145,3 +145,30 @@ def test_absent(salt_call_cli, public_ip_addr, resource_group, connection_auth):
     assert data["changes"]["new"] == expected["changes"]["new"]
     assert data["changes"]["old"]["name"] == expected["changes"]["old"]["name"]
     assert data["result"] == expected["result"]
+
+
+@pytest.mark.run(order=-3)
+def test_absent_second_ip(salt_call_cli, public_ip_addr2, resource_group, connection_auth):
+    expected = {
+        "changes": {
+            "new": {},
+            "old": {
+                "name": public_ip_addr2,
+            },
+        },
+        "comment": f"Public IP address {public_ip_addr2} has been deleted.",
+        "name": public_ip_addr2,
+        "result": True,
+    }
+    ret = salt_call_cli.run(
+        "--local",
+        "state.single",
+        "azurerm_network.public_ip_address_absent",
+        name=public_ip_addr2,
+        resource_group=resource_group,
+        connection_auth=connection_auth,
+    )
+    data = list(ret.data.values())[0]
+    assert data["changes"]["new"] == expected["changes"]["new"]
+    assert data["changes"]["old"]["name"] == expected["changes"]["old"]["name"]
+    assert data["result"] == expected["result"]

--- a/tests/integration/states/test_resource_group.py
+++ b/tests/integration/states/test_resource_group.py
@@ -1,45 +1,8 @@
 import pytest
 
 
-# @pytest.mark.run(order=1)
-@pytest.mark.skip(reason="resource group already exists")
-def test_present(salt_call_cli, resource_group, location, connection_auth):
-    expected = {
-        "__id__": resource_group,
-        "__run_num__": 0,
-        "__sls__": None,
-        "changes": {
-            "new": {
-                "location": location,
-                "name": resource_group,
-                "type": "Microsoft.Resources/resourceGroups",
-                "properties": {"provisioning_state": "Succeeded"},
-            },
-            "old": {},
-        },
-        "comment": f"Resource group {resource_group} has been created.",
-        "name": resource_group,
-        "result": True,
-    }
-    # ret = resource.resource_group_present(resource_group, location, connection_auth=connection_auth)
-    ret = salt_call_cli.run(
-        "--local",
-        "state.single",
-        "azurerm_resource.resource_group_present",
-        name=resource_group,
-        location=location,
-        connection_auth=connection_auth,
-    )
-    data = list(ret.data.values())[0]
-    data["changes"]["new"].pop("id")
-    data.pop("duration")
-    data.pop("start_time")
-    assert data == expected
-
-
-# @pytest.mark.run(order=1, after="test_present", before="test_absent")
-@pytest.mark.skip(reason="resource group already exists")
-def test_changes(salt_call_cli, resource_group, location, tags, connection_auth):
+@pytest.mark.run(order=1, before="test_changes_remove_tag")
+def test_changes_add_tag(salt_call_cli, resource_group, location, tags, connection_auth):
     expected = {
         "__id__": resource_group,
         "__run_num__": 0,
@@ -75,36 +38,37 @@ def test_changes(salt_call_cli, resource_group, location, tags, connection_auth)
     assert data == expected
 
 
-# @pytest.mark.run(order=-1)
-@pytest.mark.skip(reason="do not delete this rg during testing")
-def test_absent(salt_call_cli, resource_group, location, tags, connection_auth):
+@pytest.mark.run(order=1, after="test_changes_add_tag")
+def test_changes_remove_tag(salt_call_cli, resource_group, location, connection_auth):
     expected = {
         "__id__": resource_group,
         "__run_num__": 0,
         "__sls__": None,
         "changes": {
-            "new": {},
-            "old": {
+            "new": {
                 "location": location,
                 "name": resource_group,
                 "properties": {"provisioning_state": "Succeeded"},
-                "tags": tags,
                 "type": "Microsoft.Resources/resourceGroups",
             },
+            "old": {},
         },
-        "comment": f"Resource group {resource_group} has been deleted.",
+        "comment": f"Resource group {resource_group} has been created.",
         "name": resource_group,
         "result": True,
     }
+
     ret = salt_call_cli.run(
         "--local",
         "state.single",
-        "azurerm_resource.resource_group_absent",
+        "azurerm_resource.resource_group_present",
         name=resource_group,
+        location=location,
         connection_auth=connection_auth,
+        tags=None,  # Set tags to None
     )
     data = list(ret.data.values())[0]
+    data["changes"]["new"].pop("id")
     data.pop("duration")
     data.pop("start_time")
-    expected["changes"]["old"]["id"] = data["changes"]["old"]["id"]
     assert data == expected

--- a/tests/integration/states/test_resource_group.py
+++ b/tests/integration/states/test_resource_group.py
@@ -1,7 +1,8 @@
 import pytest
 
 
-@pytest.mark.run(order=1)
+# @pytest.mark.run(order=1)
+@pytest.mark.skip(reason="resource group already exists")
 def test_present(salt_call_cli, resource_group, location, connection_auth):
     expected = {
         "__id__": resource_group,
@@ -36,7 +37,8 @@ def test_present(salt_call_cli, resource_group, location, connection_auth):
     assert data == expected
 
 
-@pytest.mark.run(order=1, after="test_present", before="test_absent")
+# @pytest.mark.run(order=1, after="test_present", before="test_absent")
+@pytest.mark.skip(reason="resource group already exists")
 def test_changes(salt_call_cli, resource_group, location, tags, connection_auth):
     expected = {
         "__id__": resource_group,
@@ -73,7 +75,8 @@ def test_changes(salt_call_cli, resource_group, location, tags, connection_auth)
     assert data == expected
 
 
-@pytest.mark.run(order=-1)
+# @pytest.mark.run(order=-1)
+@pytest.mark.skip(reason="do not delete this rg during testing")
 def test_absent(salt_call_cli, resource_group, location, tags, connection_auth):
     expected = {
         "__id__": resource_group,


### PR DESCRIPTION


### What does this PR do?
Add pytest-ordering to pyproject.toml, Add test_absent func to second public ip address

### What issues does this PR fix or reference?
Fixes: tests failing due to pytests not running in the correct order

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
