### PR TITLE
Don't restrict VM sizes to deprecated VirtualMachineSizeTypes

### DIFF
--- a/changelog/56.fixed.md
+++ b/changelog/56.fixed.md
@@ -1,0 +1,1 @@
+Removed restriction of VM sizes to known ones

--- a/src/saltext/azurerm/clouds/azurerm.py
+++ b/src/saltext/azurerm/clouds/azurerm.py
@@ -786,8 +786,6 @@ def request_instance(vm_, kwargs=None):
     VirtualHardDisk = getattr(compute_models, "VirtualHardDisk")
     # pylint: disable=invalid-name
     VirtualMachine = getattr(compute_models, "VirtualMachine")
-    # pylint: disable=invalid-name
-    VirtualMachineSizeTypes = getattr(compute_models, "VirtualMachineSizeTypes")
 
     subscription_id = config.get_cloud_config_value(
         "subscription_id", get_configured_provider(), __opts__, search_global=False
@@ -1107,7 +1105,7 @@ def request_instance(vm_, kwargs=None):
         location=vm_["location"],
         plan=None,
         hardware_profile=HardwareProfile(
-            vm_size=getattr(VirtualMachineSizeTypes, vm_["size"].lower(), kwargs),
+            vm_size=vm_["size"].lower(),
         ),
         storage_profile=StorageProfile(
             os_disk=os_disk,

--- a/src/saltext/azurerm/clouds/azurerm.py
+++ b/src/saltext/azurerm/clouds/azurerm.py
@@ -750,7 +750,7 @@ def create_network_interface(call=None, kwargs=None):
     return _get_network_interface(kwargs["iface_name"], kwargs["resource_group"])
 
 
-def request_instance(vm_, kwargs=None):
+def request_instance(vm_, kwargs=None):  # pylint: disable=unused-argument
     """
     Request a VM from Azure.
     """


### PR DESCRIPTION
### What does this PR do?
This PR removes a lookup of the provided Virtual Machine size against the deprecated enum VirtualMachineSIzeTypes during cloud VM deployment. Any user-provided SKU that isn't present in this deprecated enum will fail to deploy, despite the error message from Azure containing the SKU in its list of valid values.

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-azurerm/issues/56

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [N/A] Docs
- [N/A] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [N/A] Tests written/updated

### Commits signed with GPG?
No
